### PR TITLE
refactor(components): rename ModeloRNA to Modelos and update navigation

### DIFF
--- a/web/src/components/ContentManager.tsx
+++ b/web/src/components/ContentManager.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
-import ModeloRNA from '@/components/ModeloRNA';
 import Prediccion from '@/components/Prediccion';
 import EDA from '@/components/EDA';
 import { Dataset } from '@/components/Dataset';
 import ForceGraph from '@/components/ForceGraph';
+import Modelos from '@/components/Modelos';
 
 declare global {
     interface Window {
@@ -74,8 +74,8 @@ export default function ContentManager() {
                 return <ForceGraph />; 
             case 'dataset':
                 return <Dataset />;
-            case 'modelo':
-                return <ModeloRNA />;
+            case 'modelos':
+                return <Modelos />;
             case 'prediccion':
                 return <Prediccion />;
             case 'eda':

--- a/web/src/components/Dataset.tsx
+++ b/web/src/components/Dataset.tsx
@@ -1,6 +1,8 @@
 export function Dataset() {
     return (
-        <article className="flex flex-col items-center justify-center gap-8 text-gray-700 lg:mb-[-20px] dark:text-gray-300 p-32  2xl:p-48 2xl:mx-44 xl:my-12 md:flex-row">
+        <>
+        <div className="mt-24"></div>
+        <article className="flex flex-col items-center justify-center gap-8 text-gray-700 lg:mb-[-20px] dark:text-gray-300 p-4 lg:p-32  2xl:p-48 2xl:mx-44 xl:my-12 md:flex-row">
             <div className="[&>p]:mb-4 [&>p>strong]:text-[#27c0ff] dark:[&>p>strong]:text-[#27c0ff] [&>p>strong]:font-normal [&>p>strong]:font-mono text-pretty order-2 md:order-1">
                 <div className="flex items-center mb-6 text-3xl font-semibold gap-x-3 text-black/80 dark:text-white">
 
@@ -25,7 +27,9 @@ export function Dataset() {
                 src="Kaggle.png"
                 alt="kaggle"
                 className="order-1 object-contain w-64 h-64 p-6 md:order-2 rotate-3 lg:p-6 lg:w-64 rounded-2xl bg-black/30 dark:bg-zinc-500/5 ring-1 ring-black/70 dark:ring-white/20 transform-gpu animate-spinTilted"
-            />
+                />
         </article>
+        <div className="mb-24"></div>
+    </>
     );
 }

--- a/web/src/components/ForceGraph.tsx
+++ b/web/src/components/ForceGraph.tsx
@@ -255,8 +255,8 @@ const ForceGraph: React.FC = () => {
         }}
       />
 
-      <div className="fixed lg:right-28 right-20 lg:mt-[18rem] z-10 mt-52 max-w-xs p-6 backdrop-blur-md rounded-xl space-y-3 opacity-80 bg-[#f9fafb] dark:bg-black/20">
-        <div className="text-md font-semibold dark:text-white/90 text-black/80">
+      <div className="fixed lg:right-28 sm:mt-20 sm:right-8 right-20 lg:mt-[18rem] z-10 mt-52 max-w-xs p-6 backdrop-blur-md rounded-xl space-y-3 opacity-80 bg-[#f9fafb] dark:bg-black/20 hidden sm:block">
+        <div className="lg:text-lg text-sm font-semibold dark:text-white/90 text-black/80">
           Cantidad de Transacciones
         </div>
 
@@ -268,7 +268,7 @@ const ForceGraph: React.FC = () => {
           return (
             <div
               key={label}
-              className="flex items-center justify-between text-sm"
+              className="flex items-center justify-between text-xs lg:text-sm"
             >
               <div className="flex items-center space-x-2">
                 <div

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -18,9 +18,9 @@ const navItems = [
     url: "eda",
   },
   {
-    title: "Modelo RNA",
-    label: "Modelo RNA",
-    url: "modelo",
+    title: "Modelos",
+    label: "Modelsos",
+    url: "modelos",
   },
   {
     title: "Predicción",

--- a/web/src/components/Modelos.tsx
+++ b/web/src/components/Modelos.tsx
@@ -1,4 +1,4 @@
-export default function ModeloRNA() {
+export default function Modelos() {
     return (
         <div className="w-full h-full flex flex-col items-center justify-center p-8 overflow-y-auto">
             MODELO RNA


### PR DESCRIPTION
- Rename ModeloRNA component to Modelos for better naming consistency
- Update navigation links and labels to reflect the component rename
- Adjust responsive styles in ForceGraph and Dataset components
- Remove old ModeloRNA component file